### PR TITLE
Feature: Moving to TMDB api for poster images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Discord webhook support.
 - Discord config addition in the plugin page.
+- Moving to TMDB api for fetching poster image.
+- Depreacting the scrapper config from plugin page.
 - Plugin page update.
 - Code refactoring to support future clients support.
 

--- a/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Newsletters/Configuration/PluginConfiguration.cs
@@ -85,7 +85,8 @@ public class PluginConfiguration : BasePluginConfiguration
         }
 
         // default Scraper config
-        ApiKey = string.Empty;
+        // Deprecating imgur support
+        // ApiKey = string.Empty;
 
         // System Paths
         DataPath = string.Empty;
@@ -105,7 +106,8 @@ public class PluginConfiguration : BasePluginConfiguration
         SeriesEnabled = true;
 
         // poster hosting
-        PHType = "Imgur";
+        // Deprecating imgur support
+        // PHType = "Imgur";
         Hostname = string.Empty;
 
         // default discord fields
@@ -235,20 +237,22 @@ public class PluginConfiguration : BasePluginConfiguration
 
     // Scraper Config
 
-    /// <summary>
-    /// Gets or sets a value indicating hosting type.
-    /// </summary>
-    public string PHType { get; set; }
+    // / <summary>
+    // / Gets or sets a value indicating hosting type.
+    // / </summary>
+    // Deprecating imgur support
+    // public string PHType { get; set; }
 
     /// <summary>
     /// Gets or sets a value for JF hostname accessible outside of network.
     /// </summary>
     public string Hostname { get; set; }
 
-    /// <summary>
-    /// Gets or sets a string setting.
-    /// </summary>
-    public string ApiKey { get; set; }
+    // / <summary>
+    // / Gets or sets a string setting.
+    // / </summary>
+    // Deprecating imgur support
+    // public string ApiKey { get; set; }
 
     // -----------------------------------
 

--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -82,9 +82,10 @@
                         </details>
                     </div>
                     <br>
-
+                    
+                    <!-- Deprecating scraper configuration part as we have moved to tmdb api for poster images -->
                     <!-- Scraper configuration Details -->
-                    <div id="HiddenDetails" name="ScraperConfig" class="DropdownSection">
+                    <!-- <div id="HiddenDetails" name="ScraperConfig" class="DropdownSection">
                         <details>
                             <summary>Scraper Config</summary><br>
                             <div class="selectContainer">
@@ -112,7 +113,7 @@
                         </details>
                     </div>
 
-                    <br>
+                    <br> -->
                     <!-- SMTP Server Details -->
                     <div id="HiddenDetails" name="ServerDetails" class="DropdownSection">
                         <details>
@@ -329,10 +330,10 @@
                     //librariesEnabled
                     config.SeriesEnabled = document.querySelector('#SeriesEnabled').checked;
                     config.MoviesEnabled = document.querySelector('#MoviesEnabled').checked;
-                    //scraperConfig
+                    //scraperConfig (Deprecated)
+                    //config.PHType = document.querySelector('#HostingSelector').value;
+                    //config.ApiKey = document.querySelector('#ApiKey').value;
                     //hosting options
-                    config.PHType = document.querySelector('#HostingSelector').value;
-                    config.ApiKey = document.querySelector('#ApiKey').value;
                     config.Hostname = document.querySelector('#Hostname').value;
 
                     ApiClient.updatePluginConfiguration(NewsletterConfig.pluginUniqueId, config).then(function (result) {
@@ -373,12 +374,12 @@
                     //librariesEnabled
                     document.querySelector('#SeriesEnabled').checked = config.SeriesEnabled;
                     document.querySelector('#MoviesEnabled').checked = config.MoviesEnabled;
-                    //scraperConfig
+                    //scraperConfig (Deprecated)
+                    //document.querySelector('#HostingSelector').value = config.PHType;
+                    //hideScraperConfig();
+                    //showScraperConfig(config.PHType);
+                    //document.querySelector('#ApiKey').value = config.ApiKey;
                     //hosting options
-                    document.querySelector('#HostingSelector').value = config.PHType;
-                    hideScraperConfig();
-                    showScraperConfig(config.PHType);
-                    document.querySelector('#ApiKey').value = config.ApiKey;
                     document.querySelector('#Hostname').value = config.Hostname;
 
                     Dashboard.hideLoadingMsg();
@@ -441,12 +442,13 @@
                 alert("Test discord message sent!");
                 return false;
             });
-
-            document.querySelector('#HostingSelector')
-                .addEventListener('change', function() {
-                hideScraperConfig();
-                showScraperConfig(this.value);
-            });
+            
+            // Scrapper config (Deprecated)
+            // document.querySelector('#HostingSelector')
+            //     .addEventListener('change', function() {
+            //     hideScraperConfig();
+            //     showScraperConfig(this.value);
+            // });
 
         </script>
     </div>

--- a/Jellyfin.Plugin.Newsletters/Scanner/PosterImageHandler.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/PosterImageHandler.cs
@@ -1,27 +1,14 @@
 #pragma warning disable 1591, SYSLIB0014, CA1002, CS0162
 using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Jellyfin.Plugin.Newsletters.Configuration;
 using Jellyfin.Plugin.Newsletters.LOGGER;
 using Jellyfin.Plugin.Newsletters.Scripts.ENTITIES;
-using Jellyfin.Plugin.Newsletters.Scripts.SCRAPER;
 using Jellyfin.Plugin.Newsletters.Shared.DATA;
-using MediaBrowser.Common.Configuration;
-using MediaBrowser.Common.Plugins;
-using MediaBrowser.Controller;
-using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Tasks;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 // using Microsoft.Extensions.Logging;
 
@@ -50,22 +37,92 @@ public class PosterImageHandler
 
     public string FetchImagePoster(JsonFileObj item)
     {
-        // Check which config option for posters are selected
-        logger.Debug($"HOSTING TYPE: {config.PHType}");
-        switch (config.PHType)
-        {
-            case "Imgur":
-                return UploadToImgur(item.PosterPath);
-                break;
-            case "JfHosting":
-                return $"{config.Hostname}/Items/{item.ItemID}/Images/Primary";
-                break;
-            default:
-                return "Something Went Wrong";
-                break;
-        }
+        WebClient wc = new();
+        string apiKey = "d63d13c187e20a4d436a9fd842e7e39c";
 
-        // return UploadToImgur(posterFilePath);
+        try
+        {
+            foreach (var kvp in item.ExternalIds)
+            {
+                var externalIdName = kvp.Key;
+                var externalIdValue = kvp.Value;
+                string url = string.Empty;
+
+                logger.Debug($"Trying to fetch TMDB poster path using {externalIdName} => {externalIdValue}");
+
+                if (externalIdName == "tmdb")
+                {
+                    if (item.Type == "Series")
+                    {
+                        url = $"https://api.themoviedb.org/3/tv/{externalIdValue}?api_key={apiKey}";
+                    }
+                    else if (item.Type == "Movie")
+                    {
+                        url = $"https://api.themoviedb.org/3/movie/{externalIdValue}?api_key={apiKey}";
+                    }
+                }
+                else
+                {
+                    url = $"https://api.themoviedb.org/3/find/{externalIdValue}?external_source={externalIdName}&api_key={apiKey}";
+                }
+
+                string response = wc.DownloadString(url);
+                logger.Debug("TMDB Response: " + response);
+
+                JObject json = JObject.Parse(response);
+
+                // It can be in movie_results or tv_results depending on the type
+                JToken? posterPathToken = null;
+
+                if (externalIdName == "tmdb")
+                {
+                    // When using direct TMDB ID (no movie_results or tv_results array)
+                    posterPathToken = json["poster_path"];
+                }
+                else
+                {
+                    // When using external IDs like imdb_id, tvdb_id, etc.
+                    if (item.Type == "Series")
+                    {
+                        posterPathToken = json["tv_results"]?.FirstOrDefault()?["poster_path"];
+                    }
+                    else if (item.Type == "Movie")
+                    {
+                        posterPathToken = json["movie_results"]?.FirstOrDefault()?["poster_path"];
+                    }
+                }
+
+                if (posterPathToken != null)
+                {
+                    string posterPath = posterPathToken.ToString();
+                    logger.Debug("TMDB Poster Path: " + posterPath);
+                    return "https://image.tmdb.org/t/p/original" + posterPath;
+                }
+                else
+                {
+                    logger.Debug($"TMDB Poster path not found for {externalIdName} => {externalIdValue}");
+                    logger.Debug("Trying the next...");
+                }
+            }
+
+            // If we're here that means we were not able to find the poster path
+            // return an empty string
+            return string.Empty;
+        }
+        catch (WebException e)
+        {
+            logger.Debug("WebClient Return STATUS: " + e.Status);
+            logger.Debug(e.ToString().Split(")")[0].Split("(")[1]);
+            try
+            {
+                return e.ToString().Split(")")[0].Split("(")[1];
+            }
+            catch (Exception ex)
+            {
+                logger.Error("Error caught while trying to parse webException error: " + ex);
+                return "ERR";
+            }
+        }
     }
 
     private string UploadToImgur(string posterFilePath)

--- a/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
@@ -124,6 +124,14 @@ public class Scraper
         totalLibCount = items.Count;
         logger.Info($"Scan Size: {totalLibCount}");
         logger.Info($"Scanning '{type}'");
+
+        var allowedExternalIds = new Dictionary<string, string>
+        {
+            { "Imdb", "imdb_id" },
+            { "Tmdb", "tmdb" },
+            { "Tvdb", "tvdb_id" },
+        };
+
         foreach (BaseItem item in items)
         {
             logger.Debug("---------------");
@@ -175,7 +183,10 @@ public class Scraper
 
                     foreach (var kvp in series.ProviderIds)
                     {
-                        logger.Debug($"External ID: {kvp.Key} => {kvp.Value}");
+                        if (allowedExternalIds.TryGetValue(kvp.Key, out var mappedKey))
+                        {
+                            logger.Debug($"External ID: {allowedExternalIds[kvp.Key]} => {kvp.Value}");
+                        }
                     }
                 }
                 catch (Exception e)
@@ -186,10 +197,14 @@ public class Scraper
                 }
 
                 JsonFileObj currFileObj = new JsonFileObj();
+
                 foreach (var kvp in series.ProviderIds)
                 {
-                    // logger.Info($"External ID - {kvp.Key}: {kvp.Value}");
-                    currFileObj.ExternalIds[kvp.Key] = kvp.Value;
+                    if (allowedExternalIds.TryGetValue(kvp.Key, out var mappedKey))
+                    {
+                        // logger.Debug($"External ID: {kvp.Key} => {kvp.Value}");
+                        currFileObj.ExternalIds[allowedExternalIds[kvp.Key]] = kvp.Value;
+                    }                    
                 }
 
                 currFileObj.Filename = episode.Path;
@@ -404,7 +419,7 @@ public class Scraper
             }
         }
 
-        logger.Debug("Uploading poster...");
+        logger.Debug("Grabbing poster...");
         logger.Debug(currObj.ItemID);
         logger.Debug(currObj.PosterPath);
         // return string.Empty;

--- a/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/Scraper.cs
@@ -172,6 +172,11 @@ public class Scraper
                     // logger.Info($"CustomRating: " + series.CustomRating);
                     logger.Debug($"CommunityRating: " + series.CommunityRating); // 8.5, 9.2, etc
                     logger.Debug($"RunTime: " + (int)((float)episode.RunTimeTicks! / 10000 / 60000) + " minutes");
+
+                    foreach (var kvp in series.ProviderIds)
+                    {
+                        logger.Debug($"External ID: {kvp.Key} => {kvp.Value}");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -181,6 +186,12 @@ public class Scraper
                 }
 
                 JsonFileObj currFileObj = new JsonFileObj();
+                foreach (var kvp in series.ProviderIds)
+                {
+                    // logger.Info($"External ID - {kvp.Key}: {kvp.Value}");
+                    currFileObj.ExternalIds[kvp.Key] = kvp.Value;
+                }
+
                 currFileObj.Filename = episode.Path;
                 currFileObj.Title = series.Name;
                 currFileObj.Type = type;

--- a/Jellyfin.Plugin.Newsletters/Shared/Entities/JsonFileObj.cs
+++ b/Jellyfin.Plugin.Newsletters/Shared/Entities/JsonFileObj.cs
@@ -31,6 +31,7 @@ public class JsonFileObj
         RunTime = 0;
         OfficialRating = string.Empty;
         CommunityRating = 0.0f;
+        ExternalIds = new Dictionary<string, string>();
     }
 
     public string Filename { get; set; }
@@ -62,6 +63,9 @@ public class JsonFileObj
     public string OfficialRating { get; set; }
 
     public float? CommunityRating { get; set; }
+
+    //Dictionary to store external IDs like IMDb, TMDb, etc.
+    public Dictionary<string, string> ExternalIds { get; }
 
     public JsonFileObj ConvertToObj(IReadOnlyList<ResultSetValue> row)
     {

--- a/README.md
+++ b/README.md
@@ -13,17 +13,6 @@ This plugin automacially scans a users library (default every 4 hours), populate
     <img src='https://github.com/Cloud9Developer/Jellyfin-Newsletter-Plugin/blob/master/NewsletterExample.png?raw=true'/><br>
 </p>
 
-# Current Limitations
-
-1. Imgur's API is one available option to upload poster images for newsletter emails to fetch images. Imgur (according to their Documentation) limits uploads to 12,500/day.
-   - HOWEVER, according to some documentation I have just discovered, there is a limit of 500 requests/hour for each user _(IP address)_ hitting the API
-   - **This plugin is configured to reference existing Images from previous scans (including current) as to not duplicate requests to Imgur and use up the daily upload limit**
-   - Sign up to get an API key in order to use this plugin.
-     - Helpful Links:
-       - https://dev.to/bearer/how-to-configure-the-imgur-api-2ap9
-       - http://siberiancmscustomization.blogspot.com/2020/10/how-to-get-imgur-client-id.html
-   - ***Users can bypass this limitation as of V0.5.0 with the ability to use Jellyfin's API to serve images!***
-
 # File Structure
 
 To ensure proper images are being pulled from Jellyfin's database, ensure you follow the standard Organization Scheme for naming and organizing your files. https://jellyfin.org/docs/general/server/media/books
@@ -85,6 +74,8 @@ Manifest is up an running! You can now import the manifest in Jellyfin and this 
 
 # Configuration
 
+**Note** :- In previous version of Jellyfin Newsletter imgur or JF server was used for the poster image. This is now deprecated as we have moved to the tmdb api for fetching the poster image internally.
+
 ## General Config
 
 ### Server URL
@@ -109,26 +100,6 @@ For defaults, see `Jellyfin.Plugin.Newsletters/Templates/`
 ### EntryData HTML
 
 - The formatting for each individual entry/series/movie that was found and will be sent out
-
-## Scraper/Scanner Config
-
-### Poster Hosting Type
-
-- The type of poster hosting you want to use
-  - Options include:
-    - Imgur (Default)
-    - Local Hosting from Jellyfin's API
-
-### Imgur API Key
-
-- Your Imgur API key (Client ID) to upload images to be available in the newsletter
-
-### Hostname
-
-- Your servername/hostname/DNS entry (and Port if applicable) to allow users to access images hosted locally on your server.
-  - i.e. https://myDNSentry.com:8096
-    - **NOTE:** do not put a trailing '/' at the end of the url
-- This is now used as a possible data tag! (even if you don't use self-hosting, set this if you want the `{ServerURL}` to work)
 
 ## Email & SMTP Config
 

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "Newsletters"
 guid: "60f478ab-2dd6-4ea0-af10-04d033f75979"
 imageUrl: "https://raw.githubusercontent.com/Cloud9Developer/Jellyfin-Newsletter-Plugin/master/logo.png"
 version: "0.7.0.0"
-targetAbi: "10.9.0.0"
+targetAbi: "10.10.0.0"
 framework: "net8.0"
 overview: "Send newsletters for recently added media"
 description: "This plugin automacially scans a users library (default every 4 hours), populates a list of recently added (not previously scanned) media, sends out the messages to configured clients(email, discord webhook)."
@@ -15,6 +15,7 @@ artifacts:
 changelog: >
   - Discord webhook support.
   - Discord config addition in the plugin page.
+  - Moving to TMDB api for fetching poster image.
   - Plugin page update.
   - Code refactoring to support future clients support.
   FULL CHANGELOG: https://raw.githubusercontent.com/Cloud9Developer/Jellyfin-Newsletter-Plugin/master/CHANGELOG.md


### PR DESCRIPTION
This PR removes the need of imgur api or JF server (external) for poster image. We have moved to the TMDB api for fetching the poster image url and directly using that in our clients.